### PR TITLE
CSHARP-1525: JsonBuffer can exhaust memory.

### DIFF
--- a/src/MongoDB.Bson/IO/JsonReaderSettings.cs
+++ b/src/MongoDB.Bson/IO/JsonReaderSettings.cs
@@ -28,6 +28,21 @@ namespace MongoDB.Bson.IO
         // private static fields
         private static JsonReaderSettings __defaults = null; // delay creation to pick up the latest default values
 
+        /// <summary>
+        /// TODO BD
+        /// </summary>
+        public bool AutoBufferReset { get; set; } = true;
+
+        /// <summary>
+        /// TODO BD
+        /// </summary>
+        public int ReadChunkSize { get; set; } = 2048;
+
+        /// <summary>
+        /// TODO BD
+        /// </summary>
+        public int MinResetBufferSize { get; set; } = 512;
+
         // constructors
         /// <summary>
         /// Initializes a new instance of the JsonReaderSettings class.


### PR DESCRIPTION
Follow up for https://github.com/mongodb/mongo-csharp-driver/pull/388.
I think we should try to reset the buffer automatically, and not expose this to a user.

1. Auto reset buffer added. Trying to reset automatically after each token read, with respecting bookmarks.
2. Added JsonBuffer config options