### PR TITLE
CSHARP-3663: Add basic logging mechanism

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -153,7 +153,7 @@ Task("Test")
             NoBuild = true,
             NoRestore = true,
             Configuration = configuration,
-            ArgumentCustomization = args => args.Append("-- RunConfiguration.TargetPlatform=x64")
+            ArgumentCustomization = args => args.Append("--logger \"console;verbosity=detailed\" -- RunConfiguration.TargetPlatform=x64")
         };
         switch (target.ToLowerInvariant())
         {

--- a/src/MongoDB.Driver.Core/Logger/ILogger.cs
+++ b/src/MongoDB.Driver.Core/Logger/ILogger.cs
@@ -1,0 +1,11 @@
+﻿namespace MongoDB.Driver.Logger
+{
+    internal interface ILogger
+    {
+        public void Log(LogLevel logLevel, string format, params object[] arguments);
+    }
+
+    internal interface ILogger<TCatergory> : ILogger
+    {
+    }
+}

--- a/src/MongoDB.Driver.Core/Logger/ILoggerExtentions.cs
+++ b/src/MongoDB.Driver.Core/Logger/ILoggerExtentions.cs
@@ -1,0 +1,8 @@
+﻿namespace MongoDB.Driver.Logger
+{
+    internal static class ILoggerExtentions
+    {
+        public static void LogInfo<T>(this ILogger<T> logger, string message) =>
+            logger?.Log(LogLevel.Information, "{0}: {1}", typeof(T).Name, message);
+    }
+}

--- a/src/MongoDB.Driver.Core/Logger/ILoggerFactory.cs
+++ b/src/MongoDB.Driver.Core/Logger/ILoggerFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace MongoDB.Driver.Logger
+{
+    internal interface ILoggerFactory
+    {
+        public ILogger<TCatergory> CreateLogger<TCatergory>();
+    }
+}

--- a/src/MongoDB.Driver.Core/Logger/LogLevel.cs
+++ b/src/MongoDB.Driver.Core/Logger/LogLevel.cs
@@ -1,0 +1,12 @@
+﻿namespace MongoDB.Driver.Logger
+{
+    internal enum LogLevel
+    {
+        None,
+        Error,
+        Warning,
+        Information,
+        Debug,
+        Trace
+    }
+}

--- a/tests/MongoDB.Driver.Core.TestHelpers/Logging/TestLoggable.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/Logging/TestLoggable.cs
@@ -1,0 +1,19 @@
+﻿using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Logger;
+using Xunit.Abstractions;
+
+namespace MongoDB.Driver.Core.TestHelpers.Logging
+{
+    public class TestLoggable
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TestLoggable(ITestOutputHelper output)
+        {
+            _output = Ensure.IsNotNull(output, nameof(output));
+        }
+
+        internal ILogger<TCatergory> CreateLogger<TCatergory>() =>
+            new XunitLogger<TCatergory>(_output);
+    }
+}

--- a/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLogger.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLogger.cs
@@ -1,0 +1,21 @@
+﻿using MongoDB.Driver.Core.Misc;
+using MongoDB.Driver.Logger;
+using Xunit.Abstractions;
+
+namespace MongoDB.Driver.Core.TestHelpers.Logging
+{
+    internal sealed class XunitLogger<TCategory> : ILogger<TCategory>
+    {
+        private readonly ITestOutputHelper _output;
+
+        public XunitLogger(ITestOutputHelper output)
+        {
+            _output = Ensure.IsNotNull(output, nameof(output));
+        }
+
+        public void Log(LogLevel logLevel, string format, params object[] arguments)
+        {
+            _output.WriteLine($"{logLevel}>{format}", arguments);
+        }
+    }
+}

--- a/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLoggerFactory.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/Logging/XunitLoggerFactory.cs
@@ -1,0 +1,11 @@
+﻿using MongoDB.Driver.Logger;
+using Xunit.Abstractions;
+
+namespace MongoDB.Driver.Core.TestHelpers.Logging
+{
+    internal static class XunitLoggerFactory
+    {
+        public static ILogger<TCatergory> CreateLogger<TCatergory>(ITestOutputHelper testOutputHelper) =>
+            new XunitLogger<TCatergory>(testOutputHelper);
+    }
+}

--- a/tests/MongoDB.Driver.Core.TestHelpers/Properties/AssemblyInfo.cs
+++ b/tests/MongoDB.Driver.Core.TestHelpers/Properties/AssemblyInfo.cs
@@ -13,6 +13,8 @@
 * limitations under the License.
 */
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("MongoDB.Driver.Core.Tests")]

--- a/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
+++ b/tests/MongoDB.Driver.Core.Tests/Core/ConnectionPools/ExclusiveConnectionPoolTests.cs
@@ -29,12 +29,14 @@ using MongoDB.Driver.Core.Connections;
 using MongoDB.Driver.Core.Events;
 using MongoDB.Driver.Core.Helpers;
 using MongoDB.Driver.Core.Servers;
+using MongoDB.Driver.Core.TestHelpers.Logging;
 using Moq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace MongoDB.Driver.Core.ConnectionPools
 {
-    public class ExclusiveConnectionPoolTests
+    public class ExclusiveConnectionPoolTests : TestLoggable
     {
         private Mock<IConnectionFactory> _mockConnectionFactory;
         private DnsEndPoint _endPoint;
@@ -43,7 +45,7 @@ namespace MongoDB.Driver.Core.ConnectionPools
         private ConnectionPoolSettings _settings;
         private ExclusiveConnectionPool _subject;
 
-        public ExclusiveConnectionPoolTests()
+        public ExclusiveConnectionPoolTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
         {
             _mockConnectionFactory = new Mock<IConnectionFactory> { DefaultValue = DefaultValue.Mock };
             _endPoint = new DnsEndPoint("localhost", 27017);
@@ -872,7 +874,8 @@ namespace MongoDB.Driver.Core.ConnectionPools
                 _endPoint,
                 connectionPoolSettings ?? _settings,
                 connectionFactory ?? _mockConnectionFactory.Object,
-                _capturedEvents);
+                _capturedEvents,
+                CreateLogger<ExclusiveConnectionPool>());
         }
 
         private void InitializeAndWait()


### PR DESCRIPTION
- Abstract logger interface, app is responsible for the implementation.
- Can be extended to be used by MongoClient, by specifying MongoClientSettings.LoggerFactory
- xUnit adapter.